### PR TITLE
run-windows cmd cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ If you're a developer and you want to take over the Windows Singleplayer Edition
 * 1: Download or clone this repository.
 * 2: After you unpack the .zip (if you just downloaded it) or it finishes cloning (if you cloned it), open up the folder that it created.
 * 3: In this folder there will be a **run-windows.cmd**, execute this to start everything up.
-* 4: What you need to do *first* before you can run the game is initialize the database. You only have to do this once.
-* 5: Once that's finished, you can safely run the game with option 1.
+* 5: You can simply run the game with option 1.
 * 6: When you're done, make sure to use the "exit" option in the menu to properly shut everything down.
-
 
 # Getting Started: Linux
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ If you're a developer and you want to take over the Windows Singleplayer Edition
 * 1: Download or clone this repository.
 * 2: After you unpack the .zip (if you just downloaded it) or it finishes cloning (if you cloned it), open up the folder that it created.
 * 3: In this folder there will be a **run-windows.cmd**, execute this to start everything up.
-* 5: You can simply run the game with option 1.
-* 6: When you're done, make sure to use the "exit" option in the menu to properly shut everything down.
+* 4: You can simply run the game with option 1.
+* 5: When you're done, make sure to use the "exit" option in the menu to properly shut everything down.
 
 # Getting Started: Linux
 

--- a/run-windows.cmd
+++ b/run-windows.cmd
@@ -36,16 +36,14 @@ taskkill /F /IM mysqld*
 taskkill /F /IM java*
 cls
 cd %database%
-call START ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%CD%\share\english" --datadir="%CD%\data"
-PING localhost -n 4 >NUL
+call START /min ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%CD%\share\english" --datadir="%CD%\data"
 cls
 SET /p username=Please enter the user to make an admin: 
 call %mariadbpath%mysql.exe -uroot -e "USE global; UPDATE `members` SET `rights` = '2' WHERE `members`.`username` = '%username%';"
-PING localhost -n 3 >NUL
-echo
+echo:
 echo %username% is now an Administrator!
 call %mariadbpath%mysqladmin.exe -uroot shutdown
-echo
+echo:
 pause
 goto start
 
@@ -83,15 +81,13 @@ mkdir %home%..\.runite_rs\runescape
 robocopy data\cache\ %userprofile%\.runite_rs\runescape\ /MIR /IS
 cd %database%
 mkdir data
-call START ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%CD%\share\english" --datadir="%CD%\data"
-PING localhost -n 4 >NUL
+call START /B ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%CD%\share\english" --datadir="%CD%\data"
 call %mariadbpath%mysql.exe -uroot -e "CREATE DATABASE global;
 call %mariadbpath%mysql.exe -uroot -e "CREATE DATABASE server;
 call %mariadbpath%mysql.exe -uroot global < "%data%\global.sql"
 echo:
 echo Databases initialized!
 taskkill /F /IM mysqld*
-pause
 goto start
 
 

--- a/run-windows.cmd
+++ b/run-windows.cmd
@@ -1,37 +1,37 @@
 @echo off
-:# Thanks to the OpenRSC team who I adapted this script from, much love <3
+:: Thanks to the OpenRSC team who I adapted this script from, much love <3
 SET mariadbpath="%~dp0\database\bin\"
 SET data="%~dp0\data\"
 SET database="%~dp0\database\"
 SET home=%~dp0
-:<------------Begin Start------------>
-REM Initial menu displayed to the user
+
+
 :start
+:: Initial menu displayed to the user
 cls
+if not exist %database%\data\ goto initDB
 echo:
 echo What would you like to do?
 echo:
 echo Choices:
 echo   1. Run the game
-echo   2. Initialize the database. (Only needs to be run once!)
-echo   3. Reset the database.
-echo   4. Grant a player admin rights.
-echo   5. Exit.
-SET /P action=Please enter a number choice from above:
+echo   2. Reset the database.
+echo   3. Grant a player admin rights.
+echo   4. Exit.
+SET /P action=Please enter a number choice from above: 
 echo:
 if /i "%action%"=="1" goto run
-if /i "%action%"=="2" goto initDB
-if /i "%action%"=="3" goto reset
-if /i "%action%"=="4" goto role
-if /i "%action%"=="5" goto exit
+if /i "%action%"=="2" goto reset
+if /i "%action%"=="3" goto role
+if /i "%action%"=="4" goto exit
 echo Error! %action% is not a valid option. Press enter to try again.
 echo:
 SET /P action=""
 goto start
-:<------------End Start------------>
 
-:<------------Begin Role----------->
+
 :role
+:: Grant player admin rights
 taskkill /F /IM mysqld*
 taskkill /F /IM java*
 cls
@@ -42,51 +42,40 @@ cls
 SET /p username=Please enter the user to make an admin: 
 call %mariadbpath%mysql.exe -uroot -e "USE global; UPDATE `members` SET `rights` = '2' WHERE `members`.`username` = '%username%';"
 PING localhost -n 3 >NUL
-echo: 
+echo
 echo %username% is now an Administrator!
 call %mariadbpath%mysqladmin.exe -uroot shutdown
-echo:
+echo
 pause
 goto start
-:<------------End Role------------->
 
-:<------------Begin Exit------------>
+
 :exit
-REM Shuts down existing processes
+:: Shuts down existing processes
 taskkill /F /IM Java*
 taskkill /F /IM mysqld*
 exit
-:<------------End Exit------------>
 
-:<------------Begin Run------------>
+
 :run
+:: Launch Client and Server
 cls
 cd %database%
-start /b "Database" %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%CD%\share\english" --datadir="%CD%\data"
-PING localhost -n 6 >NUL
-
+start /min "Database" %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%CD%\share\english" --datadir="%CD%\data"
 cls
 echo:
 echo Starting 2009scape.
 echo:
 cd %home%
-start /b "Management Server" java -Xms1024m -Xmx1024m -jar ms.jar
-PING localhost -n 3 >NUL
-
-
-echo "Starting server-------------------------"
-start "Server - Press CTRL+C to close correctly" java -Xms1024m -Xmx1024m -cp server.jar core.Server %home%\worldprops\default.json
-PING localhost -n 10 >NUL
-
-echo "Starting client-------------------------"
-start "" java -Xms1024m -Xmx1024m -jar client.jar
+start /min "Management Server" java -Xms1024m -Xmx1024m -jar ms.jar
+start /min "Server - CTRL+C to close" java -Xms1024m -Xmx1024m -cp server.jar core.Server %home%\worldprops\default.json
+start /min "Client - CTRL+C to close" java -Xms1024m -Xmx1024m -jar client.jar
 echo:
 goto start
-:<------------End Run------------>
 
-:<------------Begin initDB------------>
+
 :initDB
-REM Shuts down existing processes
+:: Setup mysql tables
 taskkill /F /IM Java*
 taskkill /F /IM mysqld*
 cd %home%
@@ -102,17 +91,14 @@ call %mariadbpath%mysql.exe -uroot global < "%data%\global.sql"
 echo:
 echo Databases initialized!
 taskkill /F /IM mysqld*
-echo:
 pause
 goto start
-:<------------End initDB------------>
 
-:<------------Begin Reset------------>
+
 :reset
-REM Shuts down existing processes
+:: Confirmation menu for reset
 taskkill /F /IM Java*
 taskkill /F /IM mysqld*
-REM Verifies the user wishes to clear existing player data
 cls
 echo:
 echo Are you ABSOLUTELY SURE that you want to reset all game databases?
@@ -122,15 +108,15 @@ echo:
 SET /P confirmwipe=""
 echo:
 if /i "%confirmwipe%"=="yes" goto wipe
-if /i "%confirmwipe%"=="no" goto start
 echo Error! %confirmwipe% is not a valid option.
 pause
 goto start
-REM Starts up the database server and imports both server and player database files to replace anything previously existing
+
+
 :wipe
+:: Delete database and re-init
 cls
 cd %database%
 rm -fr data
 mkdir data
 goto initDB
-:<------------End Reset------------>

--- a/run-windows.cmd
+++ b/run-windows.cmd
@@ -1,9 +1,9 @@
 @echo off
 :: Thanks to the OpenRSC team who I adapted this script from, much love <3
-SET mariadbpath="%~dp0\database\bin\"
-SET data="%~dp0\data\"
-SET database="%~dp0\database\"
-SET home=%~dp0
+set mariadbpath="%~dp0\database\bin\"
+set data="%~dp0\data\"
+set database="%~dp0\database\"
+set home=%~dp0
 
 
 :start
@@ -18,7 +18,7 @@ echo   1. Run the game
 echo   2. Reset the database.
 echo   3. Grant a player admin rights.
 echo   4. Exit.
-SET /P action=Please enter a number choice from above: 
+set /p action=Please enter a number choice from above: 
 echo:
 if /i "%action%"=="1" goto run
 if /i "%action%"=="2" goto reset
@@ -26,19 +26,19 @@ if /i "%action%"=="3" goto role
 if /i "%action%"=="4" goto exit
 echo Error! %action% is not a valid option. Press enter to try again.
 echo:
-SET /P action=""
+set /p action=""
 goto start
 
 
 :role
 :: Grant player admin rights
-taskkill /F /IM mysqld*
-taskkill /F /IM java*
+taskkill /f /im mysqld*
+taskkill /f /im java*
 cls
 cd %database%
-call START /min ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%CD%\share\english" --datadir="%CD%\data"
+call start /min ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%cd%\share\english" --datadir="%cd%\data"
 cls
-SET /p username=Please enter the user to make an admin: 
+set /p username=Please enter the user to make an admin: 
 call %mariadbpath%mysql.exe -uroot -e "USE global; UPDATE `members` SET `rights` = '2' WHERE `members`.`username` = '%username%';"
 echo:
 echo %username% is now an Administrator!
@@ -50,8 +50,8 @@ goto start
 
 :exit
 :: Shuts down existing processes
-taskkill /F /IM Java*
-taskkill /F /IM mysqld*
+taskkill /f /im Java*
+taskkill /f /im mysqld*
 exit
 
 
@@ -59,7 +59,7 @@ exit
 :: Launch Client and Server
 cls
 cd %database%
-start /min "Database" %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%CD%\share\english" --datadir="%CD%\data"
+start /min "Database" %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%cd%\share\english" --datadir="%cd%\data"
 cls
 echo:
 echo Starting 2009scape.
@@ -74,34 +74,34 @@ goto start
 
 :initDB
 :: Setup mysql tables
-taskkill /F /IM Java*
-taskkill /F /IM mysqld*
+taskkill /f /im Java*
+taskkill /f /im mysqld*
 cd %home%
 mkdir %home%..\.runite_rs\runescape
-robocopy data\cache\ %userprofile%\.runite_rs\runescape\ /MIR /IS
+robocopy data\cache\ %userprofile%\.runite_rs\runescape\ /mir /is > nul 2>&1
 cd %database%
 mkdir data
-call START /B ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%CD%\share\english" --datadir="%CD%\data"
+call start /b ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%cd%\share\english" --datadir="%cd%\data" > nul 2>&1
 call %mariadbpath%mysql.exe -uroot -e "CREATE DATABASE global;
 call %mariadbpath%mysql.exe -uroot -e "CREATE DATABASE server;
 call %mariadbpath%mysql.exe -uroot global < "%data%\global.sql"
 echo:
 echo Databases initialized!
-taskkill /F /IM mysqld*
+taskkill /f /im mysqld*
 goto start
 
 
 :reset
 :: Confirmation menu for reset
-taskkill /F /IM Java*
-taskkill /F /IM mysqld*
+taskkill /f /im Java*
+taskkill /f /im mysqld*
 cls
 echo:
 echo Are you ABSOLUTELY SURE that you want to reset all game databases?
 echo:
 echo To confirm the database reset, type yes and press enter.
 echo:
-SET /P confirmwipe=""
+set /p confirmwipe=""
 echo:
 if /i "%confirmwipe%"=="yes" goto wipe
 echo Error! %confirmwipe% is not a valid option.

--- a/run-windows.cmd
+++ b/run-windows.cmd
@@ -37,9 +37,11 @@ taskkill /f /im java*
 cls
 cd %database%
 call start /min ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%cd%\share\english" --datadir="%cd%\data"
+ping localhost -n 4 > nul
 cls
 set /p username=Please enter the user to make an admin: 
 call %mariadbpath%mysql.exe -uroot -e "USE global; UPDATE `members` SET `rights` = '2' WHERE `members`.`username` = '%username%';"
+ping localhost -n 3 > nul
 echo:
 echo %username% is now an Administrator!
 call %mariadbpath%mysqladmin.exe -uroot shutdown
@@ -59,15 +61,19 @@ exit
 :: Launch Client and Server
 cls
 cd %database%
+echo Starting Database.
 start /min "Database" %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%cd%\share\english" --datadir="%cd%\data"
+ping localhost -n 6 > nul
 cls
 echo:
 echo Starting 2009scape.
 echo:
 cd %home%
 start /min "Management Server" java -Xms1024m -Xmx1024m -jar ms.jar
+ping localhost -n 3 > nul
 start /min "Server - CTRL+C to close" java -Xms1024m -Xmx1024m -cp server.jar core.Server %home%\worldprops\default.json
-start /min "Client - CTRL+C to close" java -Xms1024m -Xmx1024m -jar client.jar
+ping localhost -n 10 > nul
+start /min "" java -Xms1024m -Xmx1024m -jar client.jar
 echo:
 goto start
 
@@ -82,6 +88,7 @@ robocopy data\cache\ %userprofile%\.runite_rs\runescape\ /mir /is > nul 2>&1
 cd %database%
 mkdir data
 call start /b ""  %mariadbpath%mysqld.exe --console --skip-grant-tables --lc-messages-dir="%cd%\share\english" --datadir="%cd%\data" > nul 2>&1
+ping localhost -n 4 > nul
 call %mariadbpath%mysql.exe -uroot -e "CREATE DATABASE global;
 call %mariadbpath%mysql.exe -uroot -e "CREATE DATABASE server;
 call %mariadbpath%mysql.exe -uroot global < "%data%\global.sql"


### PR DESCRIPTION
Features:

- Auto-initialize the database if %database%\data\ doesn't exist
- Server CLI, Client CLI, and Management CLI are all launched minimized
- Shortened and cleaned for future maintenance

Things I'm not sure about:

I removed the localhost pings which I assume were basically just sleeping the script for a few seconds to the let process spawn correctly. Can be added back if they are required for low-end systems but seems to work fine without them.

